### PR TITLE
feat: select env with domain

### DIFF
--- a/lib/plugins/whistle.nohost/lib/uiServer/cgi/selectEnv.js
+++ b/lib/plugins/whistle.nohost/lib/uiServer/cgi/selectEnv.js
@@ -1,7 +1,8 @@
-const { COOKIE_NAME, ENV_MAX_AGE, decodeURIComponentSafe, getClientId } = require('../../util');
+const { COOKIE_NAME, ENV_MAX_AGE, decodeURIComponentSafe, getClientId, getDomain } = require('../../util');
 
 module.exports = (ctx) => {
   const { name, envId, redirect } = ctx.request.query;
+  const hostname = (ctx.get('host') || '').split(':')[0];
   const envName = decodeURIComponentSafe(envId);
   const env = ctx.envMgr.setEnv(getClientId(ctx), name, envName);
   let value = '';
@@ -11,6 +12,7 @@ module.exports = (ctx) => {
   ctx.cookies.set(COOKIE_NAME, value, {
     path: '/',
     expires: new Date(Date.now() + (ENV_MAX_AGE * 1000)),
+    domain: getDomain(hostname),
   });
   if (redirect && typeof redirect === 'string') {
     ctx.redirect(redirect);


### PR DESCRIPTION
If not set domain, it will use the url domain.
There may be 2 whistle_nohost_env in the cookie.